### PR TITLE
Adding missing dependencies.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,15 @@
 
 ## Requirements
 
-Uses curl
+It uses curl, C compiler & dev tools and file. In Ubuntu or similar Debian systems:
+```bash
+apt install curl build-essential file
+```
+
+In Dockerfile:
+```dockerfile
+RUN DEBIAN_FRONTEND=noninteractive apt install -y curl build-essential file
+```
 
 ## Install
 


### PR DESCRIPTION
I was installing this plugin into a new (almost) fresh machine and found these dependencies. It is useful for who is installing from scratch, like using Docker.

_Note: Maybe there is another missing dependencies because my Docker already had some basic tools pre-installed._