### PR TITLE
added progress reporting to time-consuming compilation step, NOP functionality difference

### DIFF
--- a/bin/download
+++ b/bin/download
@@ -39,7 +39,7 @@ get_source() {
 	local sqlite_tarball="sqlite-autoconf-$long_version.tar.gz"
 	local sqlite_url="https://www.sqlite.org/$release_year/$sqlite_tarball"
 
-	echo "Downloading sqlite from $sqlite_url"
+	echo "downloading sqlite source code; url=$sqlite_url; destDir=$ASDF_DOWNLOAD_PATH"
 
 	curl --silent "$sqlite_url" --output "$ASDF_DOWNLOAD_PATH/$sqlite_tarball"
 	tar -xf "$ASDF_DOWNLOAD_PATH/$sqlite_tarball" --strip-components=1 -C "$ASDF_DOWNLOAD_PATH"

--- a/bin/install
+++ b/bin/install
@@ -24,6 +24,7 @@ install_sqlite() {
 		exit 1
 	fi
 
+	echo "configure && compile && make install: this might take a minute; buildDir=$ASDF_DOWNLOAD_PATH; installDir=${install_path}"
 	compile_source "$install_path"
 }
 


### PR DESCRIPTION
added progress reporting to time-consuming compilation step, NOP functionality difference.

1. Emits a new progress message before starting sqlite compilation.

2. Clarifies existing download progress message: that a source release
   is being downloaded, and shows the download dir.

Motivation: It wasn't obvious from the original message that installing
sqlite3 with this plugin would take more than a few seconds.  Compiling
sqlite takes approx two minutes or so on my computer, so the new message
is hopefully reassuring.

After
-----

```bash
$ asdf plugin remove sqlite
$ asdf plugin add sqlite https://github.com/psranga/asdf-sqlite.git
$ time asdf install sqlite latest
downloading sqlite source code; url=https://www.sqlite.org/2024/sqlite-autoconf-3460100.tar.gz; destDir=/home/ubuntu/.asdf/downloads/sqlite/3.46.1
configure && compile && make install: this might take a minute; buildDir=/home/ubuntu/.asdf/downloads/sqlite/3.46.1; installDir=/home/ubuntu/.asdf/installs/sqlite/3.46.1

real    1m48.542s
user    2m36.780s
sys     0m5.426s
$ which sqlite3
/home/ubuntu/.asdf/shims/sqlite3
```

Before
------

```bash
$ asdf plugin add sqlite https://github.com/cLupus/asdf-sqlite.git
$ time asdf install sqlite latest
Downloading sqlite from https://www.sqlite.org/2024/sqlite-autoconf-3460100.tar.gz

real    1m42.141s
user    2m31.023s
sys     0m5.254s
$ which sqlite3
/home/ubuntu/.asdf/shims/sqlite3
```
